### PR TITLE
feat: build immersive virtual store experience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+*.pyo

--- a/Read-me.md
+++ b/Read-me.md
@@ -1,175 +1,111 @@
+# But Market 360° – plateforme de courses virtuelle
 
+## 🎯 Objectif
 
-#  Ticket de caisse – TP Python
+Cette évolution transforme le TP « Ticket de caisse » en une **application web immersive** permettant de réaliser des courses virtuelles avec :
 
-##  Présentation
+- un **catalogue enrichi** (+30 produits) persisté en SQLite ;
+- une **interface moderne animée** pour scanner, visualiser et encaisser ;
+- une **IA embarquée** générant instantanément les produits absents du catalogue ;
+- la production automatique d’un **ticket de caisse numérique et textuel**.
 
-Ce projet consiste à développer un **système de génération de tickets de caisse** en Python.
-Il s’agit d’un TP encadré visant à apprendre :
-
-* l’utilisation de **Python** en ligne de commande,
-* la **gestion de données** (catalogue produits, TVA, poids/volume),
-* le **versionnement Git** et l’organisation de projet (**Trello, GitHub, branches, tags**),
-* la **gestion des besoins client** (Lot 1 → Lot 2 avec nouvelles fonctionnalités).
-
----
-
-##  Fonctionnalités
-
-### Lot 1
-
-* Catalogue produit simple (code, nom, prix HT).
-* Calcul **Total HT, TVA (10%), Total TTC**.
-* Affichage ticket formaté (colonnes article, quantité, prix unitaire, total HT).
-* README explicatif et plan de tests.
-
-### Lot 2
-
-* Catalogue enrichi (code, nom, prix HT, TVA spécifique, poids/volume, origine).
-* Gestion de la **TVA variable** (10% ou 20%).
-* Affichage du **poids/volume unitaire** et du **poids/volume total**.
-* Affichage de l’**origine** des produits.
-* Ticket complet, réaliste, proche d’un ticket de caisse imprimé.
-* Nouveaux tests (cas TVA mixte, poids calculé, plusieurs produits).
+L’expérience simule un passage en caisse complet (client, caissier, panier, encaissement) et reste extensible vers d’autres canaux (PDF, API externe, etc.).
 
 ---
 
-##  Structure du projet
+## ✨ Fonctionnalités principales
 
-```
-.
-├── main.py        # Script Lot 1
-├── main2.py       # Script Lot 2
-├── README.md      # Documentation
-├── tests/         # (optionnel) Dossiers de tests unitaires
-└── data/          # (optionnel) Base produits JSON ou CSV
-```
-
----
-
-##  Installation
-
-### 1. Cloner le projet
-
-```bash
-git clone https://github.com/jb2brest/tpiut.git
-cd tpiut
-git checkout 2025-Lannion-3A2-SAQUET-ROINET
-```
-
-### 2. Prérequis
-
-* Python ≥ 3.8
-* Aucune dépendance externe nécessaire (utilise uniquement la bibliothèque standard).
+| Domaine | Description |
+| --- | --- |
+| Catalogue dynamique | 33 produits pré-chargés (épicerie, frais, boissons, hygiène, animaux) avec TVA, unité, origine et prix HT. |
+| Assistant IA | Lors d’un scan d’article inconnu, un moteur heuristique catégorise le produit, génère un code, un prix cohérent, une TVA adaptée et l’ajoute à la base sans interrompre la commande. |
+| Panier interactif | Ajout rapide depuis les cartes produit, mise à jour des quantités, suppression, calcul automatique HT/TVA/TTC. |
+| Encaissement | Sélection du caissier, saisie du client, validation côté serveur, sauvegarde de la commande et des lignes de ticket. |
+| Ticket réaliste | Vue récapitulative responsive + ticket ASCII imprimable (et option d’impression navigateur). |
+| API JSON | Points d’entrée `/api/products`, `/api/lookup`, `/checkout` pour intégrer l’application à d’autres systèmes. |
 
 ---
 
-##  Utilisation
-
-### Lot 1 (TVA fixe 10%)
-
-```bash
-python3 main.py "But Market" "Lisa" "C01:2|C02:1|C03:3"
-```
-
-**Exemple de sortie** :
+## 🏗️ Architecture
 
 ```
-========================================
-              But Market               
-Vendeur : Lisa                 30/09/2025 14:12
-----------------------------------------
-Article              Qté  PU HT Total HT
-----------------------------------------
-Coca Cola              2   1.20    2.40
-Biscottes              1   2.50    2.50
-Crackers               3   1.80    5.40
-----------------------------------------
-Total HT                          10.30 €
-TVA (10%)                          1.03 €
-Total TTC                         11.33 €
-========================================
-   Merci de votre visite et à bientôt !  
-========================================
+app/
+├── __init__.py           # Création de l’application Flask
+├── ai.py                 # Génération déterministe des produits « IA »
+├── database.py           # Connexion SQLite + session_scope
+├── models.py             # SQLAlchemy ORM (Product, Cashier, Order, OrderItem)
+├── receipts.py           # Construction du ticket ASCII
+├── seed_data.py          # Chargement initial du catalogue et des caissiers
+├── views.py              # Routes web et API (catalogue, IA, checkout, ticket)
+├── static/
+│   ├── css/style.css     # Thème néon, animations et responsive design
+│   └── js/app.js         # Gestion du panier, appels API, UI dynamique
+└── templates/            # Vues HTML (base, accueil, ticket)
 ```
+
+- **Flask 3** pilote les routes HTML/API.
+- **SQLAlchemy 2** gère les entités et la persistance.
+- Le moteur IA repose sur des règles métier reproductibles (hash + bibliothèques de mots clés) pour garantir un prix réaliste et une origine cohérente.
+- Les tickets sont stockés pour consultation ultérieure (`/receipt/<id>`).
 
 ---
 
-### Lot 2 (TVA variable, poids/volume et origine)
+## 🚀 Mise en route
 
-```bash
-python3 main.py "But Market" "Lisa" "C01:1|C02:3|C03:4"
-```
+1. **Installer les dépendances**
 
-**Exemple de sortie** :
+   ```bash
+   python3 -m venv .venv
+   source .venv/bin/activate
+   pip install -r requirements.txt
+   ```
 
-```
-But Market
-Ticket numéro : 2200
-Date : 30/09/2025
+2. **Lancer le serveur**
 
-Vous avez été servi par : Lisa
+   ```bash
+   flask --app app:create_app --debug run
+   ```
 
-NB  Desc.           Pds/vol. unit. Pds/vol. total Orig.        HT   TVA    Total
-1   pack de coca    2kg            2kg            Lituanie      5€ 20%    6.0€
-3   kilo de pdt     1kg            3kg            Espagne       1€ 10%    3.3€
-4   pack Biscotte   950g           3.8kg          France        2€ 10%    8.8€
+   > À la première exécution, la base SQLite `app/store.db` est créée et alimentée automatiquement.
 
-Total HT            16.0€
-Total TVA           2.1€
-Total TTC           18.1€
-```
+3. **Explorer l’expérience**
 
----
-
-##  Options d’évolution
-
-* Export du ticket en **PDF** ou **fichier texte**.
-* Interface graphique (Tkinter ou PyQt).
-* Base de données produits externe (CSV/JSON/SQLite).
-* Gestion des réductions et promotions.
+   - Rendez-vous sur `http://127.0.0.1:5000`.
+   - Cliquez sur « Commencer mes courses » pour dévoiler les rayons.
+   - Scannez un produit (ex. `C01`, `pâtes linguine`, `jus mangue`).
+   - L’IA crée l’article si nécessaire puis l’ajoute au panier.
+   - Sélectionnez un caissier, saisissez un client et encaissez pour afficher le ticket.
 
 ---
 
-##  Plan de tests
+## 🧠 Comment fonctionne l’IA produit ?
 
-### Lot 1
+1. **Analyse sémantique** du nom recherché (normalisation, recherche par mots clés).
+2. **Sélection d’un gabarit** (fruits, boissons, hygiène…) avec TVA, unité et origine typiques.
+3. **Génération déterministe** du prix et de l’origine via des fonctions de hachage (résultats stables).
+4. **Création persistante** dans la base `products` avec le drapeau `created_by_ai`.
 
-| Objectif                       | Commande                                      | Résultat attendu                                      |                                                          |
-| ------------------------------ | --------------------------------------------- | ----------------------------------------------------- | -------------------------------------------------------- |
-| Ticket avec 1 produit          | `python3 main.py "But Market" "Lisa" "C01:1"` | Ticket avec Coca Cola x1, HT=1.20, TVA=0.12, TTC=1.32 |                                                          |
-| Ticket avec plusieurs produits | `python3 main.py "But Market" "Lisa" "C01:2   | C02:1"`                                               | Ticket avec Coca Cola x2 + Biscottes x1, totaux corrects |
-| Code invalide                  | `python3 main.py "But Market" "Lisa" "C99:1"` | Produit ignoré, ticket sans erreur                    |                                                          |
-
-### Lot 2
-
-| Objectif             | Commande                                      | Résultat attendu                            |         |                                                             |
-| -------------------- | --------------------------------------------- | ------------------------------------------- | ------- | ----------------------------------------------------------- |
-| Produit avec TVA 20% | `python3 main.py "But Market" "Lisa" "C01:1"` | Affiche TVA 20% sur Coca, total TTC correct |         |                                                             |
-| Calcul poids total   | `python3 main.py "But Market" "Lisa" "C02:3"` | Poids total = 3kg                           |         |                                                             |
-| Mix TVA et poids     | `python3 main.py "But Market" "Lisa" "C01:1   | C02:3                                       | C03:4"` | Affiche poids total par produit, TVA mixte, totaux corrects |
+Ainsi, aucune commande n’est bloquée : chaque référence inconnue est créée « en direct » avec des informations commerciales plausibles.
 
 ---
 
-##  Livraison
+## 🧪 Scénarios de test rapides
 
-1. **Lot 1**
-
-   * Développement + commit
-   * Livraison → `git tag 3A2-B1-lot1 && git push origin 3A2-B1-lot1`
-
-2. **Lot 2**
-
-   * Développement + commit
-   * Livraison → `git tag 3A2-B1-lot2 && git push origin 3A2-B1-lot2`
+| Objectif | Action | Résultat attendu |
+| --- | --- | --- |
+| Ajout classique | Cliquer sur « Ajouter » pour `Coca Cola 1L` (quantité 2) | Panier mis à jour, totaux recalculés, pas d’erreur. |
+| Création IA | Scanner `jus mangue passion` | Produit généré (code `DRK-*`), panier mis à jour, message vert. |
+| Encaissement complet | Panier avec au moins 2 articles, choix d’un caissier, cliquer sur « Encaisser » | Redirection vers `/receipt/<id>`, ticket HTML + ASCII disponible. |
+| Mise à jour panier | Modifier la quantité d’une ligne dans le panier | Totaux recalculés en temps réel. |
+| Suppression | Retirer un article depuis le panier | Ligne supprimée, totaux actualisés. |
 
 ---
 
-##  Binôme
+## 🔮 Pistes d’amélioration
 
-* **Camille Saquet**
-* **Evan Roinet**
+- Export PDF ou envoi automatique par e-mail/SMS.
+- Gestion des promotions, cartes de fidélité, paiement en ligne.
+- Tableau de bord analytique (ventes par rayon, panier moyen).
+- Intégration d’un moteur de recommandation produit en temps réel.
 
-Groupe : **3A2 – Lannion 2025**
-
-
+Bonnes courses dans But Market 360° !

--- a/app.py
+++ b/app.py
@@ -1,0 +1,7 @@
+from app import create_app
+
+app = create_app()
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,23 @@
+from flask import Flask
+
+from .database import Base, engine
+from .seed_data import seed_database
+
+
+def create_app() -> Flask:
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///store.db"
+    app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+
+    # Ensure tables exist and seed data if empty
+    Base.metadata.create_all(bind=engine)
+    seed_database()
+
+    from .views import bp as store_bp
+
+    app.register_blueprint(store_bp)
+
+    return app
+
+
+__all__ = ["create_app"]

--- a/app/ai.py
+++ b/app/ai.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass
+from typing import Iterable, Tuple
+
+from sqlalchemy import select
+
+from .database import session_scope
+from .models import Product
+
+
+@dataclass
+class CategoryTemplate:
+    code_prefix: str
+    vat_rate: float
+    unit: str
+    unit_quantity: float
+    price_range: Tuple[float, float]
+    origins: Tuple[str, ...]
+    keywords: Tuple[str, ...]
+
+
+CATEGORY_LIBRARY: Tuple[CategoryTemplate, ...] = (
+    CategoryTemplate(
+        code_prefix="FRU",
+        vat_rate=0.055,
+        unit="kg",
+        unit_quantity=1.0,
+        price_range=(1.5, 5.0),
+        origins=("France", "Espagne", "Italie", "Maroc"),
+        keywords=("pomme", "banane", "fraise", "orange", "fruit", "poire"),
+    ),
+    CategoryTemplate(
+        code_prefix="VEG",
+        vat_rate=0.055,
+        unit="kg",
+        unit_quantity=1.0,
+        price_range=(1.0, 4.0),
+        origins=("France", "Espagne", "Pays-Bas"),
+        keywords=("carotte", "tomate", "salade", "legume", "courgette", "poivron"),
+    ),
+    CategoryTemplate(
+        code_prefix="DRK",
+        vat_rate=0.2,
+        unit="L",
+        unit_quantity=1.5,
+        price_range=(0.8, 6.0),
+        origins=("France", "Allemagne", "Belgique"),
+        keywords=("cola", "boisson", "jus", "soda", "eau", "biere", "limonade"),
+    ),
+    CategoryTemplate(
+        code_prefix="DRY",
+        vat_rate=0.055,
+        unit="pièce",
+        unit_quantity=1.0,
+        price_range=(0.5, 4.5),
+        origins=("France", "Belgique", "Allemagne"),
+        keywords=("biscuit", "pain", "cereale", "farine", "pate", "gateau"),
+    ),
+    CategoryTemplate(
+        code_prefix="HOM",
+        vat_rate=0.2,
+        unit="pièce",
+        unit_quantity=1.0,
+        price_range=(2.0, 25.0),
+        origins=("France", "Chine", "Portugal"),
+        keywords=("shampoing", "savon", "lessive", "dentifrice", "nettoyant", "eponge"),
+    ),
+    CategoryTemplate(
+        code_prefix="PET",
+        vat_rate=0.2,
+        unit="pièce",
+        unit_quantity=1.0,
+        price_range=(1.0, 40.0),
+        origins=("France", "Allemagne", "Italie"),
+        keywords=("croquette", "litiere", "jouet", "animal"),
+    ),
+)
+
+DEFAULT_CATEGORY = CategoryTemplate(
+    code_prefix="GEN",
+    vat_rate=0.2,
+    unit="pièce",
+    unit_quantity=1.0,
+    price_range=(1.0, 15.0),
+    origins=("France", "Union Européenne"),
+    keywords=(),
+)
+
+
+def _normalize(text: str) -> str:
+    return re.sub(r"\s+", " ", text.strip().lower())
+
+
+def _select_category(name: str) -> CategoryTemplate:
+    normalized = _normalize(name)
+    for template in CATEGORY_LIBRARY:
+        if any(keyword in normalized for keyword in template.keywords):
+            return template
+    return DEFAULT_CATEGORY
+
+
+def _deterministic_float(name: str, minimum: float, maximum: float) -> float:
+    digest = hashlib.sha1(name.encode("utf-8")).hexdigest()
+    value = int(digest[:8], 16) / 0xFFFFFFFF
+    return round(minimum + (maximum - minimum) * value, 2)
+
+
+def _deterministic_choice(name: str, options: Iterable[str]) -> str:
+    options = tuple(options)
+    digest = hashlib.md5(name.encode("utf-8")).hexdigest()
+    index = int(digest[:6], 16) % len(options)
+    return options[index]
+
+
+def _build_code(prefix: str, base_name: str) -> str:
+    slug = re.sub(r"[^A-Z0-9]", "", _normalize(base_name).upper())
+    slug = slug[:8] or "ITEM"
+    return f"{prefix}-{slug}"
+
+
+def ensure_product_exists(name: str) -> Product:
+    normalized = _normalize(name)
+    with session_scope() as session:
+        product = session.execute(
+            select(Product).where(Product.name.ilike(f"%{normalized}%"))
+        ).scalar_one_or_none()
+
+        if product:
+            session.expunge(product)
+            return product
+
+        template = _select_category(name)
+        price = _deterministic_float(name, *template.price_range)
+        origin = _deterministic_choice(name, template.origins)
+        code = _build_code(template.code_prefix, name)
+
+        product = Product(
+            code=code,
+            name=name.strip().title(),
+            price_ht=price,
+            vat_rate=template.vat_rate,
+            unit=template.unit,
+            unit_quantity=template.unit_quantity,
+            origin=origin,
+            created_by_ai=True,
+        )
+        session.add(product)
+        session.flush()
+        session.refresh(product)
+        session.expunge(product)
+        return product
+
+
+__all__ = ["ensure_product_exists"]

--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+BASE_DIR = Path(__file__).resolve().parent
+DATABASE_URL = f"sqlite:///{BASE_DIR / 'store.db'}"
+
+engine = create_engine(
+    DATABASE_URL,
+    connect_args={"check_same_thread": False},
+    future=True,
+)
+SessionLocal = sessionmaker(
+    bind=engine,
+    autoflush=False,
+    autocommit=False,
+    expire_on_commit=False,
+    future=True,
+)
+Base = declarative_base()
+
+
+@contextmanager
+def session_scope() -> Iterator[sessionmaker]:
+    session = SessionLocal()
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+
+__all__ = ["engine", "SessionLocal", "Base", "session_scope"]

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List
+
+from sqlalchemy import Boolean, Column, DateTime, Float, ForeignKey, Integer, Numeric, String
+from sqlalchemy.orm import Mapped, relationship
+
+from .database import Base
+
+
+class Product(Base):
+    __tablename__ = "products"
+
+    id: Mapped[int] = Column(Integer, primary_key=True)
+    code: Mapped[str] = Column(String(20), unique=True, nullable=False, index=True)
+    name: Mapped[str] = Column(String(120), nullable=False)
+    price_ht: Mapped[float] = Column(Numeric(10, 2), nullable=False)
+    vat_rate: Mapped[float] = Column(Float, nullable=False, default=0.2)
+    unit: Mapped[str] = Column(String(20), nullable=False, default="pièce")
+    unit_quantity: Mapped[float] = Column(Float, nullable=False, default=1.0)
+    origin: Mapped[str] = Column(String(80), nullable=False, default="France")
+    created_by_ai: Mapped[bool] = Column(Boolean, nullable=False, default=False)
+
+    order_items: Mapped[List["OrderItem"]] = relationship("OrderItem", back_populates="product")
+
+    def price_ttc(self) -> float:
+        return float(self.price_ht) * (1 + self.vat_rate)
+
+
+class Cashier(Base):
+    __tablename__ = "cashiers"
+
+    id: Mapped[int] = Column(Integer, primary_key=True)
+    first_name: Mapped[str] = Column(String(80), nullable=False)
+    last_name: Mapped[str] = Column(String(80), nullable=False)
+
+    orders: Mapped[List["Order"]] = relationship("Order", back_populates="cashier")
+
+    @property
+    def display_name(self) -> str:
+        return f"{self.first_name} {self.last_name.upper()}"
+
+
+class Order(Base):
+    __tablename__ = "orders"
+
+    id: Mapped[int] = Column(Integer, primary_key=True)
+    customer_name: Mapped[str] = Column(String(120), nullable=False)
+    created_at: Mapped[datetime] = Column(DateTime, nullable=False, default=datetime.utcnow)
+    cashier_id: Mapped[int] = Column(Integer, ForeignKey("cashiers.id"), nullable=False)
+
+    cashier: Mapped[Cashier] = relationship("Cashier", back_populates="orders")
+    items: Mapped[List["OrderItem"]] = relationship(
+        "OrderItem", back_populates="order", cascade="all, delete-orphan"
+    )
+
+    def total_ht(self) -> float:
+        return sum(item.total_ht for item in self.items)
+
+    def total_tva(self) -> float:
+        return sum(item.total_tva for item in self.items)
+
+    def total_ttc(self) -> float:
+        return sum(item.total_ttc for item in self.items)
+
+
+class OrderItem(Base):
+    __tablename__ = "order_items"
+
+    id: Mapped[int] = Column(Integer, primary_key=True)
+    order_id: Mapped[int] = Column(Integer, ForeignKey("orders.id"), nullable=False)
+    product_id: Mapped[int] = Column(Integer, ForeignKey("products.id"), nullable=False)
+    quantity: Mapped[float] = Column(Float, nullable=False)
+    unit_price_ht: Mapped[float] = Column(Numeric(10, 2), nullable=False)
+    vat_rate: Mapped[float] = Column(Float, nullable=False)
+
+    order: Mapped[Order] = relationship("Order", back_populates="items")
+    product: Mapped[Product] = relationship("Product", back_populates="order_items")
+
+    @property
+    def total_ht(self) -> float:
+        return float(self.unit_price_ht) * self.quantity
+
+    @property
+    def total_tva(self) -> float:
+        return self.total_ht * self.vat_rate
+
+    @property
+    def total_ttc(self) -> float:
+        return self.total_ht * (1 + self.vat_rate)

--- a/app/receipts.py
+++ b/app/receipts.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from .models import Order
+
+
+def render_receipt(order: Order) -> str:
+    header = [
+        "========================================",
+        "           But Market 360°",
+        f"Caissier : {order.cashier.display_name:<18}{order.created_at.strftime('%d/%m/%Y %H:%M')}",
+        f"Client   : {order.customer_name}",
+        "----------------------------------------",
+        "Article                Qté  PU HT  Total",
+        "----------------------------------------",
+    ]
+
+    lines = []
+    for item in order.items:
+        product = item.product
+        name = product.name[:20].ljust(20)
+        qty = f"{item.quantity:>4.2f}" if item.quantity % 1 else f"{int(item.quantity):>4}"
+        pu = f"{float(item.unit_price_ht):>6.2f}"
+        total = f"{item.total_ht:>6.2f}"
+        lines.append(f"{name}{qty} {pu} {total}")
+
+    footer = [
+        "----------------------------------------",
+        f"Total HT{'':>23}{order.total_ht():>7.2f} €",
+        f"TVA{'':>27}{order.total_tva():>7.2f} €",
+        f"Total TTC{'':>21}{order.total_ttc():>7.2f} €",
+        "========================================",
+        "   Merci de votre visite et à bientôt !",
+        "========================================",
+    ]
+
+    return "\n".join(header + lines + footer)
+
+
+__all__ = ["render_receipt"]

--- a/app/seed_data.py
+++ b/app/seed_data.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from typing import Sequence
+
+from sqlalchemy import func, select
+
+from .database import session_scope
+from .models import Cashier, Product
+
+
+CATALOG: Sequence[dict[str, object]] = (
+    {"code": "C01", "name": "Coca Cola 1L", "price_ht": 1.5, "vat_rate": 0.2, "unit": "L", "unit_quantity": 1.0, "origin": "France"},
+    {"code": "C02", "name": "Biscottes dorées", "price_ht": 2.1, "vat_rate": 0.055, "unit": "pièce", "unit_quantity": 1.0, "origin": "France"},
+    {"code": "C03", "name": "Crackers salés", "price_ht": 1.6, "vat_rate": 0.2, "unit": "pièce", "unit_quantity": 1.0, "origin": "Belgique"},
+    {"code": "F01", "name": "Pommes bio", "price_ht": 3.2, "vat_rate": 0.055, "unit": "kg", "unit_quantity": 1.0, "origin": "France"},
+    {"code": "F02", "name": "Bananes cavendish", "price_ht": 2.2, "vat_rate": 0.055, "unit": "kg", "unit_quantity": 1.0, "origin": "Guadeloupe"},
+    {"code": "F03", "name": "Orange sanguine", "price_ht": 2.9, "vat_rate": 0.055, "unit": "kg", "unit_quantity": 1.0, "origin": "Espagne"},
+    {"code": "L01", "name": "Lait demi-écrémé", "price_ht": 0.95, "vat_rate": 0.055, "unit": "L", "unit_quantity": 1.0, "origin": "France"},
+    {"code": "L02", "name": "Yaourt grec nature", "price_ht": 1.8, "vat_rate": 0.055, "unit": "pièce", "unit_quantity": 4.0, "origin": "Grèce"},
+    {"code": "L03", "name": "Beurre doux", "price_ht": 1.5, "vat_rate": 0.055, "unit": "pièce", "unit_quantity": 0.25, "origin": "France"},
+    {"code": "M01", "name": "Poulet fermier", "price_ht": 6.5, "vat_rate": 0.055, "unit": "kg", "unit_quantity": 1.0, "origin": "France"},
+    {"code": "M02", "name": "Steak haché 5%", "price_ht": 8.2, "vat_rate": 0.055, "unit": "kg", "unit_quantity": 1.0, "origin": "France"},
+    {"code": "M03", "name": "Jambon blanc", "price_ht": 3.9, "vat_rate": 0.055, "unit": "pièce", "unit_quantity": 0.2, "origin": "France"},
+    {"code": "S01", "name": "Saumon fumé", "price_ht": 12.5, "vat_rate": 0.055, "unit": "pièce", "unit_quantity": 0.3, "origin": "Norvège"},
+    {"code": "S02", "name": "Cabillaud frais", "price_ht": 10.0, "vat_rate": 0.055, "unit": "kg", "unit_quantity": 1.0, "origin": "Islande"},
+    {"code": "S03", "name": "Crevettes roses", "price_ht": 9.8, "vat_rate": 0.055, "unit": "kg", "unit_quantity": 1.0, "origin": "Madagascar"},
+    {"code": "G01", "name": "Pâtes linguine", "price_ht": 1.1, "vat_rate": 0.055, "unit": "pièce", "unit_quantity": 0.5, "origin": "Italie"},
+    {"code": "G02", "name": "Riz basmati", "price_ht": 2.4, "vat_rate": 0.055, "unit": "pièce", "unit_quantity": 1.0, "origin": "Inde"},
+    {"code": "G03", "name": "Farine de blé T55", "price_ht": 0.9, "vat_rate": 0.055, "unit": "pièce", "unit_quantity": 1.0, "origin": "France"},
+    {"code": "B01", "name": "Bière artisanale", "price_ht": 3.5, "vat_rate": 0.2, "unit": "L", "unit_quantity": 0.75, "origin": "Belgique"},
+    {"code": "B02", "name": "Jus d'orange pressé", "price_ht": 2.8, "vat_rate": 0.055, "unit": "L", "unit_quantity": 1.0, "origin": "Espagne"},
+    {"code": "B03", "name": "Thé glacé pêche", "price_ht": 1.7, "vat_rate": 0.2, "unit": "L", "unit_quantity": 1.5, "origin": "France"},
+    {"code": "H01", "name": "Shampoing doux", "price_ht": 4.2, "vat_rate": 0.2, "unit": "pièce", "unit_quantity": 0.25, "origin": "France"},
+    {"code": "H02", "name": "Gel douche marine", "price_ht": 2.9, "vat_rate": 0.2, "unit": "pièce", "unit_quantity": 0.25, "origin": "France"},
+    {"code": "H03", "name": "Lessive concentrée", "price_ht": 7.5, "vat_rate": 0.2, "unit": "L", "unit_quantity": 2.0, "origin": "France"},
+    {"code": "H04", "name": "Nettoyant multi-usages", "price_ht": 2.4, "vat_rate": 0.2, "unit": "L", "unit_quantity": 1.0, "origin": "France"},
+    {"code": "H05", "name": "Dentifrice menthol", "price_ht": 3.1, "vat_rate": 0.2, "unit": "pièce", "unit_quantity": 0.075, "origin": "France"},
+    {"code": "SN1", "name": "Chips paprika", "price_ht": 1.4, "vat_rate": 0.2, "unit": "pièce", "unit_quantity": 0.2, "origin": "Pays-Bas"},
+    {"code": "SN2", "name": "Barre chocolat noisette", "price_ht": 0.95, "vat_rate": 0.2, "unit": "pièce", "unit_quantity": 0.05, "origin": "France"},
+    {"code": "SN3", "name": "Mélange fruits secs", "price_ht": 3.8, "vat_rate": 0.055, "unit": "pièce", "unit_quantity": 0.25, "origin": "Turquie"},
+    {"code": "P01", "name": "Croquettes chat adulte", "price_ht": 12.0, "vat_rate": 0.2, "unit": "kg", "unit_quantity": 3.0, "origin": "France"},
+    {"code": "P02", "name": "Litière minérale", "price_ht": 5.5, "vat_rate": 0.2, "unit": "pièce", "unit_quantity": 6.0, "origin": "France"},
+    {"code": "P03", "name": "Friandises chien", "price_ht": 3.2, "vat_rate": 0.2, "unit": "pièce", "unit_quantity": 0.3, "origin": "Allemagne"},
+)
+
+CASHIERS: Sequence[dict[str, str]] = (
+    {"first_name": "Lisa", "last_name": "Martin"},
+    {"first_name": "Nabil", "last_name": "Cissé"},
+    {"first_name": "Ana", "last_name": "Gomez"},
+)
+
+
+def seed_database() -> None:
+    with session_scope() as session:
+        product_count = session.execute(select(func.count()).select_from(Product)).scalar_one()
+        if product_count == 0:
+            session.bulk_insert_mappings(Product, CATALOG)
+
+        cashier_count = session.execute(select(func.count()).select_from(Cashier)).scalar_one()
+        if cashier_count == 0:
+            session.bulk_insert_mappings(Cashier, CASHIERS)
+
+
+__all__ = ["seed_database"]

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1,0 +1,534 @@
+:root {
+  --bg: #0f172a;
+  --surface: #111827;
+  --accent: #6366f1;
+  --accent-light: #a5b4fc;
+  --text: #f9fafb;
+  --muted: #9ca3af;
+  --success: #10b981;
+  --warning: #f59e0b;
+  --danger: #ef4444;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Poppins", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: radial-gradient(circle at top, rgba(99, 102, 241, 0.18), transparent 60%), var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+}
+
+.app-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.5rem 4rem;
+  position: sticky;
+  top: 0;
+  background: rgba(15, 23, 42, 0.85);
+  backdrop-filter: blur(12px);
+  z-index: 100;
+}
+
+.app-header .logo {
+  font-size: 1.6rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+}
+
+.app-header .logo span {
+  color: var(--accent);
+}
+
+.app-header nav a {
+  color: var(--muted);
+  text-decoration: none;
+  margin-left: 1.5rem;
+  transition: color 0.3s ease;
+}
+
+.app-header nav a:hover {
+  color: var(--text);
+}
+
+main {
+  padding: 3rem 4rem 6rem;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 3rem;
+  align-items: center;
+  margin-bottom: 4rem;
+}
+
+.hero-text h1 {
+  font-size: clamp(2.6rem, 4vw, 3.4rem);
+  margin-bottom: 1rem;
+}
+
+.hero-text p {
+  color: var(--muted);
+  line-height: 1.6;
+  max-width: 420px;
+}
+
+.primary {
+  background: linear-gradient(135deg, var(--accent), var(--accent-light));
+  color: #0b1120;
+  border: none;
+  padding: 0.9rem 2.4rem;
+  border-radius: 999px;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 12px 30px rgba(99, 102, 241, 0.35);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.primary:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 16px 32px rgba(99, 102, 241, 0.45);
+}
+
+.hero-visual {
+  position: relative;
+  height: 280px;
+}
+
+.floating-card {
+  position: absolute;
+  width: 160px;
+  height: 110px;
+  background: rgba(17, 24, 39, 0.8);
+  border-radius: 20px;
+  border: 1px solid rgba(99, 102, 241, 0.4);
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.5);
+  animation: float 6s ease-in-out infinite;
+}
+
+.floating-card::after {
+  content: "";
+  position: absolute;
+  inset: 20px;
+  border-radius: 12px;
+  border: 1px dashed rgba(165, 180, 252, 0.4);
+}
+
+.floating-card:nth-child(1) {
+  top: 0;
+  left: 10%;
+}
+
+.floating-card:nth-child(2) {
+  top: 30%;
+  right: 10%;
+}
+
+.floating-card:nth-child(3) {
+  bottom: 0;
+  left: 40%;
+}
+
+.floating-card.delay {
+  animation-delay: 1.2s;
+}
+
+@keyframes float {
+  0%,
+  100% {
+    transform: translateY(0) rotate(0deg);
+  }
+  50% {
+    transform: translateY(-18px) rotate(3deg);
+  }
+}
+
+.store {
+  background: rgba(15, 23, 42, 0.75);
+  border-radius: 32px;
+  padding: 2.5rem;
+  box-shadow: 0 40px 80px rgba(15, 23, 42, 0.6);
+  transform: translateY(40px);
+  opacity: 0;
+  transition: transform 0.7s cubic-bezier(0.16, 1, 0.3, 1), opacity 0.7s ease;
+}
+
+.store.visible {
+  transform: translateY(0);
+  opacity: 1;
+}
+
+.toolbar {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.toolbar label {
+  display: block;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  margin-bottom: 0.5rem;
+  color: var(--muted);
+}
+
+.search-bar {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.search-bar input {
+  flex: 1;
+  padding: 0.7rem 1rem;
+  border-radius: 14px;
+  border: 1px solid rgba(99, 102, 241, 0.4);
+  background: rgba(15, 23, 42, 0.6);
+  color: var(--text);
+}
+
+.search-bar button {
+  border-radius: 14px;
+  padding: 0.7rem 1.6rem;
+  border: none;
+  background: rgba(99, 102, 241, 0.8);
+  color: var(--text);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.3s ease;
+}
+
+.search-bar button:hover {
+  background: var(--accent);
+}
+
+.hint {
+  display: block;
+  margin-top: 0.4rem;
+  color: var(--muted);
+}
+
+.store-layout {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 2rem;
+}
+
+.catalog {
+  background: rgba(17, 24, 39, 0.8);
+  border-radius: 24px;
+  padding: 1.8rem;
+  backdrop-filter: blur(8px);
+}
+
+.catalog h2 {
+  margin-top: 0;
+}
+
+.product-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.4rem;
+}
+
+.product-card {
+  background: rgba(15, 23, 42, 0.85);
+  border-radius: 22px;
+  padding: 1.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  position: relative;
+  overflow: hidden;
+  border: 1px solid transparent;
+  transition: transform 0.35s ease, border 0.35s ease, box-shadow 0.35s ease;
+}
+
+.product-card::before {
+  content: "";
+  position: absolute;
+  inset: -60%;
+  background: radial-gradient(circle, rgba(99, 102, 241, 0.25), transparent 60%);
+  transform: translateY(60%);
+  transition: transform 0.5s ease;
+}
+
+.product-card:hover {
+  transform: translateY(-6px) scale(1.01);
+  border-color: rgba(99, 102, 241, 0.6);
+  box-shadow: 0 22px 45px rgba(99, 102, 241, 0.15);
+}
+
+.product-card:hover::before {
+  transform: translateY(20%);
+}
+
+.product-card header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.product-card .code {
+  background: rgba(99, 102, 241, 0.2);
+  padding: 0.1rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  color: var(--accent-light);
+}
+
+.product-card .details p {
+  margin: 0.2rem 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.product-card footer {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.product-card input[type="number"] {
+  border-radius: 14px;
+  padding: 0.6rem 0.8rem;
+  border: 1px solid rgba(99, 102, 241, 0.4);
+  background: rgba(15, 23, 42, 0.6);
+  color: var(--text);
+}
+
+.product-card button {
+  border-radius: 14px;
+  padding: 0.6rem 1.2rem;
+  border: none;
+  background: rgba(16, 185, 129, 0.2);
+  color: var(--success);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.3s ease, transform 0.3s ease;
+}
+
+.product-card button:hover {
+  background: rgba(16, 185, 129, 0.3);
+  transform: translateY(-2px);
+}
+
+.cart {
+  background: rgba(17, 24, 39, 0.85);
+  border-radius: 24px;
+  padding: 1.8rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+  position: sticky;
+  top: 120px;
+  max-height: 70vh;
+}
+
+.cart-items {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  overflow-y: auto;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.cart-item {
+  background: rgba(15, 23, 42, 0.9);
+  border-radius: 18px;
+  padding: 1rem;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.5rem 1rem;
+  align-items: center;
+  border: 1px solid rgba(99, 102, 241, 0.2);
+  animation: slide-in 0.4s ease;
+}
+
+.cart-item .name {
+  font-weight: 600;
+}
+
+.cart-item .meta {
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.cart-item .quantity {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.cart-item .quantity input {
+  width: 60px;
+  padding: 0.4rem;
+  border-radius: 12px;
+  border: 1px solid rgba(99, 102, 241, 0.3);
+  background: rgba(15, 23, 42, 0.6);
+  color: var(--text);
+}
+
+.cart-item button {
+  background: rgba(239, 68, 68, 0.15);
+  color: var(--danger);
+  border: none;
+  border-radius: 12px;
+  padding: 0.4rem 0.8rem;
+  cursor: pointer;
+  transition: background 0.3s ease;
+}
+
+.cart-item button:hover {
+  background: rgba(239, 68, 68, 0.3);
+}
+
+@keyframes slide-in {
+  from {
+    opacity: 0;
+    transform: translateX(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+.totals {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.totals span {
+  color: var(--muted);
+}
+
+.status {
+  min-height: 1.2rem;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.status.error {
+  color: var(--danger);
+}
+
+.status.success {
+  color: var(--success);
+}
+
+.receipt-wrapper {
+  display: flex;
+  justify-content: center;
+}
+
+.receipt {
+  width: min(720px, 100%);
+  background: rgba(17, 24, 39, 0.85);
+  border-radius: 24px;
+  padding: 2.5rem;
+  box-shadow: 0 30px 60px rgba(15, 23, 42, 0.55);
+}
+
+.receipt table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1.5rem;
+}
+
+.receipt th,
+.receipt td {
+  text-align: left;
+  padding: 0.75rem 0.5rem;
+  border-bottom: 1px solid rgba(99, 102, 241, 0.2);
+}
+
+.receipt tbody tr {
+  animation: fade-in 0.45s ease;
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.receipt .meta {
+  display: block;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.actions {
+  display: flex;
+  gap: 1rem;
+  margin-top: 2rem;
+}
+
+.actions button {
+  flex: 1;
+  padding: 0.8rem 1.2rem;
+  border-radius: 14px;
+  border: 1px solid rgba(99, 102, 241, 0.4);
+  background: transparent;
+  color: var(--accent-light);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.3s ease;
+}
+
+.actions button.primary {
+  background: rgba(99, 102, 241, 0.3);
+  color: var(--text);
+}
+
+.actions button:hover {
+  background: rgba(99, 102, 241, 0.25);
+}
+
+pre {
+  background: rgba(15, 23, 42, 0.9);
+  padding: 1.2rem;
+  border-radius: 16px;
+  overflow: auto;
+  max-height: 320px;
+  border: 1px solid rgba(99, 102, 241, 0.2);
+}
+
+.hidden {
+  display: none;
+}
+
+@media (max-width: 960px) {
+  main {
+    padding: 2rem;
+  }
+
+  .store-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .cart {
+    position: static;
+    max-height: none;
+  }
+
+  .actions {
+    flex-direction: column;
+  }
+}

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -1,0 +1,251 @@
+const storeSection = document.getElementById("store");
+const startButton = document.getElementById("start-shopping");
+const productGrid = document.getElementById("product-grid");
+const cartList = document.getElementById("cart-items");
+const checkoutButton = document.getElementById("checkout");
+const statusBox = document.getElementById("status");
+const totalHtEl = document.getElementById("total-ht");
+const totalTvaEl = document.getElementById("total-tva");
+const totalTtcEl = document.getElementById("total-ttc");
+const searchInput = document.getElementById("search-product");
+const scanButton = document.getElementById("scan-button");
+const cashierSelect = document.getElementById("cashier");
+const customerInput = document.getElementById("customer");
+
+const cart = new Map();
+
+function animateStore() {
+  if (!storeSection) return;
+  storeSection.classList.remove("hidden");
+  requestAnimationFrame(() => storeSection.classList.add("visible"));
+}
+
+startButton?.addEventListener("click", animateStore);
+
+function formatCurrency(value) {
+  return new Intl.NumberFormat("fr-FR", { style: "currency", currency: "EUR" }).format(value);
+}
+
+function updateTotals() {
+  let totalHt = 0;
+  let totalTva = 0;
+
+  cart.forEach((item) => {
+    totalHt += item.price_ht * item.quantity;
+    totalTva += item.price_ht * item.quantity * item.vat_rate;
+  });
+
+  const totalTtc = totalHt + totalTva;
+  totalHtEl.textContent = formatCurrency(totalHt);
+  totalTvaEl.textContent = formatCurrency(totalTva);
+  totalTtcEl.textContent = formatCurrency(totalTtc);
+  checkoutButton.disabled = cart.size === 0;
+}
+
+function renderCart() {
+  cartList.innerHTML = "";
+  cart.forEach((item, key) => {
+    const li = document.createElement("li");
+    li.className = "cart-item";
+    li.dataset.productId = key;
+    li.innerHTML = `
+      <div>
+        <div class="name">${item.name}</div>
+        <div class="meta">${item.unit_quantity} ${item.unit} · TVA ${(item.vat_rate * 100).toFixed(1)}%</div>
+      </div>
+      <div class="quantity">
+        <label>Qté</label>
+        <input type="number" min="0.1" step="0.1" value="${item.quantity}" />
+        <button type="button">Retirer</button>
+      </div>
+      <div class="price">${formatCurrency(item.price_ht * (1 + item.vat_rate))}</div>
+    `;
+
+    const quantityInput = li.querySelector("input");
+    quantityInput.addEventListener("input", () => {
+      const value = parseFloat(quantityInput.value);
+      if (Number.isFinite(value) && value > 0) {
+        cart.get(key).quantity = value;
+        updateTotals();
+      }
+    });
+
+    const removeButton = li.querySelector("button");
+    removeButton.addEventListener("click", () => {
+      cart.delete(key);
+      renderCart();
+      updateTotals();
+    });
+
+    cartList.appendChild(li);
+  });
+}
+
+function addToCart(product, quantity) {
+  const key = product.id;
+  const current = cart.get(key);
+  if (current) {
+    current.quantity += quantity;
+  } else {
+    cart.set(key, { ...product, quantity });
+  }
+  renderCart();
+  updateTotals();
+  showStatus(`${product.name} ajouté au panier`, "success");
+}
+
+function getCardData(card) {
+  return {
+    id: Number(card.dataset.productId),
+    name: card.querySelector("h3").textContent,
+    code: card.querySelector(".code").textContent,
+    price_ht: parseFloat(card.querySelector(".price").textContent),
+    vat_rate: parseFloat(card.querySelector(".vat").textContent.replace(/[^0-9.,]/g, "")) / 100,
+    unit: card.querySelector(".unit").textContent.split(" ").pop(),
+    unit_quantity: parseFloat(card.querySelector(".unit").textContent),
+    origin: card.querySelector(".origin").textContent.replace("Origine : ", ""),
+  };
+}
+
+productGrid?.addEventListener("click", (event) => {
+  const button = event.target.closest(".add-to-cart");
+  if (!button) return;
+  const card = button.closest(".product-card");
+  const quantityInput = card.querySelector("input[type='number']");
+  const quantity = parseFloat(quantityInput.value) || 1;
+  const product = getCardData(card);
+  addToCart(product, quantity);
+  quantityInput.value = "1";
+});
+
+async function lookupProduct(query) {
+  const response = await fetch("/api/lookup", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ query }),
+  });
+
+  if (!response.ok) {
+    const payload = await response.json().catch(() => ({}));
+    throw new Error(payload.error || "Impossible d'ajouter cet article");
+  }
+
+  const payload = await response.json();
+  if (payload.created) {
+    await refreshCatalog();
+  }
+  return payload.product;
+}
+
+async function refreshCatalog() {
+  const response = await fetch("/api/products");
+  const products = await response.json();
+  productGrid.innerHTML = "";
+  products.forEach((product) => {
+    const card = document.createElement("article");
+    card.className = "product-card";
+    card.dataset.productId = product.id;
+    card.innerHTML = `
+      <header>
+        <h3>${product.name}</h3>
+        <span class="code">${product.code}</span>
+      </header>
+      <div class="details">
+        <p class="price">${product.price_ht.toFixed(2)} € HT</p>
+        <p class="vat">TVA ${(product.vat_rate * 100).toFixed(1)}%</p>
+        <p class="unit">${product.unit_quantity} ${product.unit}</p>
+        <p class="origin">Origine : ${product.origin}</p>
+      </div>
+      <footer>
+        <label>Quantité</label>
+        <input type="number" step="0.1" min="0.1" value="1" />
+        <button class="add-to-cart">Ajouter</button>
+      </footer>
+    `;
+    productGrid.appendChild(card);
+  });
+}
+
+async function handleScan() {
+  const query = searchInput.value.trim();
+  if (!query) {
+    showStatus("Saisissez un nom de produit.", "error");
+    return;
+  }
+  try {
+    const product = await lookupProduct(query);
+    addToCart(product, 1);
+    searchInput.value = "";
+  } catch (error) {
+    showStatus(error.message, "error");
+  }
+}
+
+scanButton?.addEventListener("click", handleScan);
+searchInput?.addEventListener("keydown", (event) => {
+  if (event.key === "Enter") {
+    event.preventDefault();
+    handleScan();
+  }
+});
+
+function showStatus(message, type = "info") {
+  if (!statusBox) return;
+  statusBox.textContent = message;
+  statusBox.className = `status ${type}`;
+  if (message) {
+    setTimeout(() => {
+      if (statusBox.textContent === message) {
+        statusBox.textContent = "";
+        statusBox.className = "status";
+      }
+    }, 4000);
+  }
+}
+
+checkoutButton?.addEventListener("click", async () => {
+  if (cart.size === 0) return;
+  const items = Array.from(cart.entries()).map(([productId, item]) => ({
+    productId,
+    quantity: item.quantity,
+    name: item.name,
+  }));
+
+  const payload = {
+    customer: customerInput?.value || "",
+    cashierId: Number(cashierSelect?.value),
+    items,
+  };
+
+  try {
+    checkoutButton.disabled = true;
+    checkoutButton.textContent = "Encaissement...";
+    const response = await fetch("/checkout", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      const data = await response.json().catch(() => ({}));
+      throw new Error(data.error || "Impossible de finaliser la commande");
+    }
+
+    const data = await response.json();
+    window.location.href = data.redirect;
+  } catch (error) {
+    showStatus(error.message, "error");
+    checkoutButton.disabled = false;
+    checkoutButton.textContent = "Encaisser";
+  }
+});
+
+const showTextButton = document.getElementById("show-text");
+const textTicket = document.getElementById("text-ticket");
+showTextButton?.addEventListener("click", () => {
+  if (!textTicket) return;
+  textTicket.classList.toggle("hidden");
+  showTextButton.textContent = textTicket.classList.contains("hidden")
+    ? "Voir le ticket texte"
+    : "Masquer le ticket texte";
+});

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{% block title %}But Market Virtuel{% endblock %}</title>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;500;700&display=swap" />
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}" />
+    {% block extra_head %}{% endblock %}
+  </head>
+  <body>
+    <header class="app-header">
+      <div class="logo">But Market<span>360°</span></div>
+      <nav>
+        <a href="{{ url_for('store.index') }}">Accueil</a>
+      </nav>
+    </header>
+    <main>
+      {% block content %}{% endblock %}
+    </main>
+    <script src="{{ url_for('static', filename='js/app.js') }}" defer></script>
+    {% block extra_scripts %}{% endblock %}
+  </body>
+</html>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,84 @@
+{% extends "base.html" %}
+
+{% block title %}Courses virtuelles - But Market{% endblock %}
+
+{% block content %}
+<section class="hero">
+  <div class="hero-text">
+    <h1>Faites vos courses dans notre magasin virtuel</h1>
+    <p>
+      Scannez, ajoutez au panier et laissez notre assistant IA compléter votre commande en cas d'imprévu.
+    </p>
+    <button id="start-shopping" class="primary">Commencer mes courses</button>
+  </div>
+  <div class="hero-visual">
+    <div class="floating-card"></div>
+    <div class="floating-card delay"></div>
+    <div class="floating-card"></div>
+  </div>
+</section>
+
+<section id="store" class="store hidden">
+  <div class="toolbar">
+    <div class="search">
+      <label for="search-product">Scanner un produit</label>
+      <div class="search-bar">
+        <input id="search-product" type="text" placeholder="Nom ou code" autocomplete="off" />
+        <button id="scan-button" type="button">Ajouter</button>
+      </div>
+      <small class="hint">Entrez un nom : si l'article n'existe pas, l'IA le crée instantanément.</small>
+    </div>
+    <div class="cashier">
+      <label for="cashier">Caissier</label>
+      <select id="cashier">
+        {% for cashier in cashiers %}
+        <option value="{{ cashier.id }}">{{ cashier.display_name }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="customer">
+      <label for="customer">Nom du client</label>
+      <input id="customer" type="text" placeholder="Client anonyme" />
+    </div>
+  </div>
+
+  <div class="store-layout">
+    <section class="catalog">
+      <h2>Rayons produits</h2>
+      <div class="product-grid" id="product-grid">
+        {% for product in products %}
+        <article class="product-card" data-product-id="{{ product.id }}">
+          <header>
+            <h3>{{ product.name }}</h3>
+            <span class="code">{{ product.code }}</span>
+          </header>
+          <div class="details">
+            <p class="price">{{ '%.2f' | format(product.price_ht) }} € HT</p>
+            <p class="vat">TVA {{ (product.vat_rate * 100) | round(1) }}%</p>
+            <p class="unit">{{ product.unit_quantity }} {{ product.unit }}</p>
+            <p class="origin">Origine : {{ product.origin }}</p>
+          </div>
+          <footer>
+            <label>Quantité</label>
+            <input type="number" step="0.1" min="0.1" value="1" />
+            <button class="add-to-cart">Ajouter</button>
+          </footer>
+        </article>
+        {% endfor %}
+      </div>
+    </section>
+
+    <aside class="cart" id="cart">
+      <h2>Panier</h2>
+      <ul class="cart-items" id="cart-items"></ul>
+      <div class="totals">
+        <p><span>Total HT</span><strong id="total-ht">0.00 €</strong></p>
+        <p><span>Total TVA</span><strong id="total-tva">0.00 €</strong></p>
+        <p><span>Total TTC</span><strong id="total-ttc">0.00 €</strong></p>
+      </div>
+      <button id="checkout" class="primary" disabled>Encaisser</button>
+      <div class="status" id="status"></div>
+    </aside>
+  </div>
+</section>
+{% endblock %}

--- a/app/templates/receipt.html
+++ b/app/templates/receipt.html
@@ -1,0 +1,54 @@
+{% extends "base.html" %}
+
+{% block title %}Ticket de caisse - But Market{% endblock %}
+
+{% block content %}
+<section class="receipt-wrapper">
+  <div class="receipt">
+    <h1>Ticket de caisse</h1>
+    <p><strong>Magasin :</strong> But Market 360°</p>
+    <p><strong>Caissier :</strong> {{ order.cashier.display_name }}</p>
+    <p><strong>Client :</strong> {{ order.customer_name }}</p>
+    <p><strong>Date :</strong> {{ order.created_at.strftime('%d/%m/%Y %H:%M') }}</p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Article</th>
+          <th>Quantité</th>
+          <th>PU HT</th>
+          <th>TVA</th>
+          <th>Total TTC</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for item in order.items %}
+        <tr>
+          <td>
+            <span class="name">{{ item.product.name }}</span>
+            <span class="meta">{{ item.product.unit_quantity }} {{ item.product.unit }} · Origine {{ item.product.origin }}</span>
+          </td>
+          <td>{{ '%.2f'|format(item.quantity) if item.quantity % 1 else item.quantity|int }}</td>
+          <td>{{ '%.2f'|format(item.unit_price_ht) }} €</td>
+          <td>{{ '%.1f'|format(item.vat_rate * 100) }}%</td>
+          <td>{{ '%.2f'|format(item.total_ttc) }} €</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+
+    <div class="totals">
+      <p><span>Total HT</span><strong>{{ '%.2f'|format(order.total_ht()) }} €</strong></p>
+      <p><span>Total TVA</span><strong>{{ '%.2f'|format(order.total_tva()) }} €</strong></p>
+      <p><span>Total TTC</span><strong>{{ '%.2f'|format(order.total_ttc()) }} €</strong></p>
+    </div>
+
+    <div class="actions">
+      <button onclick="window.print()" class="primary">Imprimer</button>
+      <button id="show-text" type="button">Voir le ticket texte</button>
+    </div>
+
+    <pre id="text-ticket" class="hidden">{{ receipt_text }}</pre>
+  </div>
+</section>
+{% endblock %}

--- a/app/views.py
+++ b/app/views.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+from flask import Blueprint, jsonify, redirect, render_template, request, url_for
+from sqlalchemy import select
+
+from .ai import ensure_product_exists
+from .database import session_scope
+from .models import Cashier, Order, OrderItem, Product
+from .receipts import render_receipt
+
+bp = Blueprint("store", __name__)
+
+
+@bp.route("/")
+def index() -> str:
+    with session_scope() as session:
+        products = session.execute(select(Product).order_by(Product.name)).scalars().all()
+        cashiers = session.execute(select(Cashier).order_by(Cashier.first_name)).scalars().all()
+    return render_template("index.html", products=products, cashiers=cashiers)
+
+
+@bp.post("/api/lookup")
+def lookup_product():
+    payload = request.get_json(silent=True) or {}
+    query = (payload.get("query") or "").strip()
+    if not query:
+        return jsonify({"error": "Veuillez saisir un nom ou un code produit."}), 400
+
+    with session_scope() as session:
+        product = session.execute(
+            select(Product).where(
+                (Product.code.ilike(query)) | (Product.name.ilike(f"%{query}%"))
+            )
+        ).scalar_one_or_none()
+
+    if product is None:
+        product = ensure_product_exists(query)
+        created = True
+    else:
+        created = False
+
+    return jsonify(
+        {
+            "created": created,
+            "product": {
+                "id": product.id,
+                "code": product.code,
+                "name": product.name,
+                "price_ht": float(product.price_ht),
+                "vat_rate": product.vat_rate,
+                "unit": product.unit,
+                "unit_quantity": product.unit_quantity,
+                "origin": product.origin,
+            },
+        }
+    )
+
+
+@bp.post("/checkout")
+def checkout():
+    payload = request.get_json(force=True)
+    customer = (payload.get("customer") or "Client anonyme").strip() or "Client anonyme"
+    cashier_id = payload.get("cashierId")
+    items = payload.get("items") or []
+
+    if not items:
+        return jsonify({"error": "Votre panier est vide."}), 400
+
+    with session_scope() as session:
+        cashier = session.get(Cashier, cashier_id)
+        if not cashier:
+            return jsonify({"error": "Caissier inconnu."}), 400
+
+        order = Order(customer_name=customer, cashier_id=cashier.id)
+        session.add(order)
+        session.flush()
+
+        for entry in items:
+            product_id = entry.get("productId")
+            quantity = float(entry.get("quantity", 1))
+            if quantity <= 0:
+                continue
+
+            product = session.get(Product, product_id)
+            if not product:
+                name = entry.get("name")
+                if not name:
+                    continue
+                generated = ensure_product_exists(name)
+                product = session.get(Product, generated.id)
+                if not product:
+                    continue
+
+            order_item = OrderItem(
+                order_id=order.id,
+                product_id=product.id,
+                quantity=quantity,
+                unit_price_ht=Decimal(str(product.price_ht)),
+                vat_rate=product.vat_rate,
+            )
+            session.add(order_item)
+
+        session.flush()
+        order_id = order.id
+
+    return jsonify({"orderId": order_id, "redirect": url_for("store.receipt", order_id=order_id)})
+
+
+@bp.get("/receipt/<int:order_id>")
+def receipt(order_id: int):
+    with session_scope() as session:
+        order = session.get(Order, order_id)
+        if not order:
+            return redirect(url_for("store.index"))
+        cashier = order.cashier
+        order_items = list(order.items)
+        for item in order_items:
+            item.product  # charge les produits liés
+        for item in order_items:
+            session.expunge(item.product)
+            session.expunge(item)
+        session.expunge(cashier)
+        session.expunge(order)
+        order.cashier = cashier
+        order.items = order_items
+    receipt_text = render_receipt(order)
+    return render_template("receipt.html", order=order, receipt_text=receipt_text)
+
+
+@bp.get("/api/products")
+def list_products():
+    with session_scope() as session:
+        products = session.execute(select(Product).order_by(Product.name)).scalars().all()
+    return jsonify(
+        [
+            {
+                "id": product.id,
+                "code": product.code,
+                "name": product.name,
+                "price_ht": float(product.price_ht),
+                "vat_rate": product.vat_rate,
+                "unit": product.unit,
+                "unit_quantity": product.unit_quantity,
+                "origin": product.origin,
+            }
+            for product in products
+        ]
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+flask>=3.0,<4
+sqlalchemy>=2.0,<3


### PR DESCRIPTION
## Summary
- replace the original CLI ticket demo with a Flask application that exposes catalog browsing, checkout and receipt routes
- seed a SQLite catalogue with 30+ items and let an AI helper create new products on the fly when a scan fails
- craft a neon-inspired interface with animations, dynamic cart management and printable receipts

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68dbe4d0ee6c832da9784e987f76dfe3